### PR TITLE
Look in B_SYSTEM_DATA_DIRECTORY for dictionaries

### DIFF
--- a/TolmachApp.cpp
+++ b/TolmachApp.cpp
@@ -421,7 +421,7 @@ void
 TolmachApplication::LoadDictList()
 {
   BPath pathDicts;
-  find_directory(B_USER_DATA_DIRECTORY, &pathDicts);
+  find_directory(B_SYSTEM_DATA_DIRECTORY, &pathDicts);
   pathDicts.Append(cszDictionariesDir);
   BDirectory dir(pathDicts.Path());
   BEntry entry;


### PR DESCRIPTION
Eventually, this should be replaced with BPathFinder but sine default install location is /system it makes sense to look in B_SYSTEM_DATA_DIRECTORY for dictionaries for now.
